### PR TITLE
add UnblockWithError function

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ if err != nil {
 }
 
 // process entity2 here
+// but an error happens
+
+err = mq.UnblockWithError(entity2.DefaultSortingProperty)
+if err != nil {
+// Handle error
+}
+// entity2 is now back in the MultiQueue and it is unblocked so the failed entity can be processed again
+
+entity2, err := mq.Dequeue()
+if err != nil {
+// Handle error
+}
+
+// process entity2 here
+// no error happens now
 
 err = mq.Unblock(entity2.DefaultSortingProperty)
 if err != nil {


### PR DESCRIPTION
same time the queue get reduced when the Unblock() is called, not when the "Dequeue" is called. This way we dont have to rollback the slice reduction when UnblockWithError()